### PR TITLE
Fix headers error access_token being a singer secret string

### DIFF
--- a/tap_shopify/client.py
+++ b/tap_shopify/client.py
@@ -32,7 +32,7 @@ class tap_shopifyStream(RESTStream):
         return tap_shopifyAuthenticator(
             self,
             key="X-Shopify-Access-Token",
-            value=self.config["access_token"],
+            value=str(self.config["access_token"]),
             location="header",
         )
 


### PR DESCRIPTION
Explicitly cast `access_token` to a string