### PR TITLE
Fix `RuntimeError: Loop detected in pagination`

### DIFF
--- a/tap_shopify/client.py
+++ b/tap_shopify/client.py
@@ -1,8 +1,8 @@
 """REST client handling, including tap_shopifyStream base class."""
 
 from pathlib import Path
-from urllib.parse import parse_qsl, urlsplit
 from typing import Any, Dict, Optional
+from urllib.parse import parse_qsl, urlsplit
 
 import requests
 from singer_sdk.streams import RESTStream

--- a/tap_shopify/client.py
+++ b/tap_shopify/client.py
@@ -1,6 +1,7 @@
 """REST client handling, including tap_shopifyStream base class."""
 
 from pathlib import Path
+from urllib.parse import parse_qsl, urlsplit
 from typing import Any, Dict, Optional
 
 import requests
@@ -62,7 +63,7 @@ class tap_shopifyStream(RESTStream):
         params: dict = {}
 
         if next_page_token:
-            return params
+            return dict(parse_qsl(urlsplit(next_page_token).query))
 
         context_state = self.get_context_state(context)
         last_updated = context_state.get("replication_key_value")

--- a/tap_shopify/tests/test_pagination.py
+++ b/tap_shopify/tests/test_pagination.py
@@ -26,16 +26,16 @@ class TestTapShopifyWithBaseCredentials(unittest.TestCase):
             self.basic_mock_config, ["products"]
         )
 
-        resource_url = "https://mock-store.myshopify.com/admin/api/2022-01/products.json"
+        resource_url = (
+            "https://mock-store.myshopify.com/admin/api/2022-01/products.json"
+        )
 
         rsp1 = responses.Response(
             responses.GET,
             resource_url,
             json=test_utils.customer_return_data,
             status=200,
-            headers={
-                "link": f"{resource_url}?limit=1&page_info=12345; rel=next"
-            },
+            headers={"link": f"{resource_url}?limit=1&page_info=12345; rel=next"},
         )
 
         rsp2 = responses.Response(
@@ -43,9 +43,7 @@ class TestTapShopifyWithBaseCredentials(unittest.TestCase):
             f"{resource_url}?limit=1&page_info=12345",
             json=test_utils.customer_return_data,
             status=200,
-            headers={
-                "link": f"{resource_url}?limit=1&page_info=12346; rel=next"
-            },
+            headers={"link": f"{resource_url}?limit=1&page_info=12346; rel=next"},
         )
 
         rsp3 = responses.Response(


### PR DESCRIPTION
### Error scenario

An initial request is made to

```
https:/mock-store.myshopify.com/api/2022-01/checkouts.json
```

The initial request response contains a `next` link to

```
https:/mock-store.myshopify.com/api/2022-01/checkouts.json?limit=50&page_info=2
```

A second request is made, in theory to

```
https:/mock-store.myshopify.com/api/2022-01/checkouts.json?limit=50&page_info=2
```

but actually is

```
https://mock-store.myshopify.com/api/2022-01/checkouts.json
```

since the URL parameters were not applied from the previous `next` link, so the same resource as the initial request ends up being fetched, containing the same `next` link.

Loop is detected by the SDK and an error is thrown with the message

```
RuntimeError: Loop detected in pagination. Pagination token mock-store.myshopify.com/api/2022-01/checkouts.json?limit=50&page_info=2 is identical to prior token.
```

---

Going forward, we should upgrade this tap to a newer version of the SDK that supports [pagination](https://sdk.meltano.com/en/latest/reference.html#pagination) and other similar features to abstract away complexities like this fix addresses.