### PR TITLE
No records for `transactions`, `inventory_levels` or `inventory_items` streams

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -1,32 +1,29 @@
 version: 1
 send_anonymous_usage_stats: true
 project_id: tap-shopify
+default_environment: test
+environments:
+- name: test
 plugins:
   extractors:
-    - name: tap-shopify
-      namespace: tap_shopify
-      pip_url: -e .
-      capabilities:
-        - state
-        - catalog
-        - discover
-      settings:
-        #
-        # To configure using Meltano, declare settings and their types here:
-        #  or use a .env
-        # TAP_SHOPIFY_ACCESS_TOKEN=
-        # TAP_SHOPIFY_STORE=
-        #
-        - name: access_token
-          kind: password
-        - name: store
-        - name: start_date
-        - name: admin_url
-        - name: is_plus_account
-          kind: boolean
-      config:
-        start_date: "2010-01-01T00:00:00Z"
+  - name: tap-shopify
+    namespace: tap_shopify
+    pip_url: -e .
+    capabilities:
+    - state
+    - catalog
+    - discover
+    settings:
+    - name: access_token
+      kind: password
+    - name: store
+    - name: start_date
+    - name: admin_url
+    - name: is_plus_account
+      kind: boolean
+    config:
+      start_date: '2010-01-01T00:00:00Z'
   loaders:
-    - name: target-jsonl
-      variant: andyh1203
-      pip_url: target-jsonl
+  - name: target-jsonl
+    variant: andyh1203
+    pip_url: target-jsonl

--- a/tap_shopify/streams.py
+++ b/tap_shopify/streams.py
@@ -86,7 +86,7 @@ class InventoryLevelsStream(tap_shopifyStream):
 
     name = "inventory_levels"
     path = "/inventory_levels.json"
-    records_jsonpath = "$.inventory_level[*]"
+    records_jsonpath = "$.inventory_levels[*]"
     primary_keys = ["inventory_item_id"]
     schema_filepath = SCHEMAS_DIR / "inventory_level.json"
 
@@ -111,7 +111,7 @@ class InventoryItemsStream(tap_shopifyStream):
 
     name = "inventory_items"
     path = "/inventory_items/{inventory_item_id}.json"
-    records_jsonpath = "$.inventory_items[*]"
+    records_jsonpath = "$.inventory_item"
     primary_keys = ["id"]
     schema_filepath = SCHEMAS_DIR / "inventory_item.json"
 

--- a/tap_shopify/streams.py
+++ b/tap_shopify/streams.py
@@ -17,7 +17,6 @@ class AbandonedCheckouts(tap_shopifyStream):
     records_jsonpath = "$.checkouts[*]"
     primary_keys = ["id"]
     replication_key = "updated_at"
-    replication_method = "INCREMENTAL"
     schema_filepath = SCHEMAS_DIR / "abandoned_checkout.json"
 
 
@@ -29,7 +28,6 @@ class CollectStream(tap_shopifyStream):
     records_jsonpath = "$.collects[*]"
     primary_keys = ["id"]
     replication_key = "id"
-    replication_method = "INCREMENTAL"
     schema_filepath = SCHEMAS_DIR / "collect.json"
 
     def get_url_params(self, context, next_page_token):
@@ -53,7 +51,6 @@ class CustomCollections(tap_shopifyStream):
     records_jsonpath = "$.custom_collections[*]"
     primary_keys = ["id"]
     replication_key = "updated_at"
-    replication_method = "INCREMENTAL"
     schema_filepath = SCHEMAS_DIR / "custom_collection.json"
 
 
@@ -65,7 +62,6 @@ class CustomersStream(tap_shopifyStream):
     records_jsonpath = "$.customers[*]"
     primary_keys = ["id"]
     replication_key = "updated_at"
-    replication_method = "INCREMENTAL"
     schema_filepath = SCHEMAS_DIR / "customer.json"
 
 
@@ -76,8 +72,6 @@ class LocationsStream(tap_shopifyStream):
     path = "/locations.json"
     records_jsonpath = "$.locations[*]"
     primary_keys = ["id"]
-    replication_key = None
-    replication_method = "FULL_TABLE"
     schema_filepath = SCHEMAS_DIR / "location.json"
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
@@ -94,7 +88,6 @@ class InventoryLevelsStream(tap_shopifyStream):
     path = "/inventory_levels.json"
     records_jsonpath = "$.inventory_level[*]"
     primary_keys = ["inventory_item_id"]
-    replication_key = None
     schema_filepath = SCHEMAS_DIR / "inventory_level.json"
 
     def get_child_context(self, record: dict, context: Optional[dict]) -> dict:
@@ -120,7 +113,6 @@ class InventoryItemsStream(tap_shopifyStream):
     path = "/inventory_items/{inventory_item_id}.json"
     records_jsonpath = "$.inventory_items[*]"
     primary_keys = ["id"]
-    replication_key = None
     schema_filepath = SCHEMAS_DIR / "inventory_item.json"
 
 
@@ -132,7 +124,6 @@ class MetafieldsStream(tap_shopifyStream):
     records_jsonpath = "$.metafields[*]"
     primary_keys = ["id"]
     replication_key = "updated_at"
-    replication_method = "INCREMENTAL"
     schema_filepath = SCHEMAS_DIR / "metafield.json"
 
 
@@ -144,7 +135,6 @@ class OrdersStream(tap_shopifyStream):
     records_jsonpath = "$.orders[*]"
     primary_keys = ["id"]
     replication_key = "updated_at"
-    replication_method = "INCREMENTAL"
     schema_filepath = SCHEMAS_DIR / "order.json"
 
     def post_process(self, row: dict, context: Optional[dict] = None):
@@ -178,7 +168,6 @@ class ProductsStream(tap_shopifyStream):
     records_jsonpath = "$.products[*]"
     primary_keys = ["id"]
     replication_key = "updated_at"
-    replication_method = "INCREMENTAL"
     schema_filepath = SCHEMAS_DIR / "product.json"
 
 
@@ -191,7 +180,6 @@ class TransactionsStream(tap_shopifyStream):
     path = "/orders/{order_id}/transactions.json"
     records_jsonpath = "$.transactions[*]"
     primary_keys = ["id"]
-    replication_key = None
     schema_filepath = SCHEMAS_DIR / "transaction.json"
 
 
@@ -202,6 +190,4 @@ class UsersStream(tap_shopifyStream):
     path = "/users.json"
     records_jsonpath = "$.users[*]"
     primary_keys = ["id"]
-    replication_key = None
-    replication_method = "FULL_TABLE"
     schema_filepath = SCHEMAS_DIR / "user.json"


### PR DESCRIPTION
- [`tap_shopifyStream.post_process` deduplication logic](https://github.com/Matatika/tap-shopify/blob/v0.2.0/tap_shopify/client.py#L82-L94) was filtering out `transactions` records incorrectly
- JSONPath expressions for both `inventory_levels` and `inventory_items` records were incorrect