### PR TITLE
fix: Update location id to integer

### DIFF
--- a/tap_shopify/schemas/location.json
+++ b/tap_shopify/schemas/location.json
@@ -43,7 +43,7 @@
         },
         "id": {
             "type": [
-                "number",
+                "integer",
                 "null"
             ]
         },


### PR DESCRIPTION
I noticed that all other `id` properties were being set as `integer` (e.g. [customer ID](https://github.com/Matatika/tap-shopify/blob/9c42206bbf783d2beece90047e3d0fa47d73d493/tap_shopify/schemas/customer.json#L5)) but this one is set as `number` and it was causing an error when inserting to databases.

