### PR TITLE
Pin certifi to latest working version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ license = "AGPL-3.0"
 python = "^3.9"
 requests = "^2.32.3"
 singer-sdk = "^0.43.1"
-certifi = "2025.1.31"
+certifi = "2025.1.31" # See https://github.com/certifi/python-certifi/issues/349
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.3.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ license = "AGPL-3.0"
 python = "^3.9"
 requests = "^2.32.3"
 singer-sdk = "^0.43.1"
+certifi = "2025.1.31"
 
 [tool.poetry.dev-dependencies]
 pytest = "^8.3.5"


### PR DESCRIPTION
Shopify is having an issue with SSL certificates. A fix is to pin `certifi` to the last working version: [see here](https://community.shopify.com/c/shopify-discussions/ssl-certificate-verification-failed-when-calling-webhooks-api/m-p/3030128).