### PR TITLE
fix: correct ShopifyQL schema discovery and timestamp handling

### DIFF
--- a/tap_shopify/streams.py
+++ b/tap_shopify/streams.py
@@ -390,8 +390,12 @@ class ShopifyQLStream(tap_shopifyStream):
     @cached_property
     def schema(self) -> dict:
         """Discover schema by probing the API with a 1-day window."""
-        probe_query = re.sub(r"\bSINCE\s+\S+", "", self._configured_query, flags=re.IGNORECASE)
-        probe_query = re.sub(r"\bUNTIL\s+\S+", "", probe_query, flags=re.IGNORECASE).strip()
+        probe_query = re.sub(
+            r"\bSINCE\s+\S+", "", self._configured_query, flags=re.IGNORECASE
+        )
+        probe_query = re.sub(
+            r"\bUNTIL\s+\S+", "", probe_query, flags=re.IGNORECASE
+        ).strip()
         probe_query += " SINCE -1d UNTIL -0d"
 
         graphql = self._GRAPHQL_TEMPLATE.format(shopifyql=json.dumps(probe_query))
@@ -420,7 +424,11 @@ class ShopifyQLStream(tap_shopifyStream):
         props = [
             th.Property(
                 col["name"],
-                th.DateTimeType if col["name"] == self.replication_key else th.StringType,
+                (
+                    th.DateTimeType
+                    if col["name"] == self.replication_key
+                    else th.StringType
+                ),
             )
             for col in columns
         ]

--- a/tap_shopify/streams.py
+++ b/tap_shopify/streams.py
@@ -379,10 +379,13 @@ class ShopifyQLStream(tap_shopifyStream):
         query_entry = kwargs.pop("query")
         self.name = query_entry["name"]
         self._configured_query = query_entry["query"]
-        self.primary_keys = query_entry.get("primary_keys") or []
-        self.replication_key = query_entry.get("replication_key")
 
         super().__init__(*args, **kwargs)
+
+        # Must be set after super().__init__(), which resets
+        # self._primary_keys / self._replication_key to their defaults.
+        self.primary_keys = query_entry.get("primary_keys") or []
+        self.replication_key = query_entry.get("replication_key")
 
     @cached_property
     def schema(self) -> dict:
@@ -400,7 +403,13 @@ class ShopifyQLStream(tap_shopifyStream):
         response.raise_for_status()
         data = response.json()
 
-        result = data.get("shopifyqlQuery") or {}
+        gql_errors = data.get("errors")
+        if gql_errors:
+            raise RuntimeError(
+                f"GraphQL errors during schema discovery for '{self.name}': {gql_errors}"
+            )
+
+        result = (data.get("data") or {}).get("shopifyqlQuery") or {}
         parse_errors = result.get("parseErrors") or []
         if parse_errors:
             raise RuntimeError(
@@ -408,7 +417,13 @@ class ShopifyQLStream(tap_shopifyStream):
             )
 
         columns = (result.get("tableData") or {}).get("columns") or []
-        props = [th.Property(col["name"], th.StringType) for col in columns]
+        props = [
+            th.Property(
+                col["name"],
+                th.DateTimeType if col["name"] == self.replication_key else th.StringType,
+            )
+            for col in columns
+        ]
         return th.PropertiesList(*props).to_dict()
 
     def prepare_request_payload(self, context, next_page_token):
@@ -441,7 +456,7 @@ class ShopifyQLStream(tap_shopifyStream):
         if gql_errors:
             raise RuntimeError(f"GraphQL errors: {gql_errors}")
 
-        result = data.get("shopifyqlQuery") or {}
+        result = (data.get("data") or {}).get("shopifyqlQuery") or {}
 
         parse_errors = result.get("parseErrors") or []
         if parse_errors:
@@ -462,5 +477,14 @@ class ShopifyQLStream(tap_shopifyStream):
         return {}
 
     def post_process(self, row, context=None):
-        """Return the row as-is — deduplication is not applicable here."""
+        """Normalize the replication key to a full timestamp.
+
+        ShopifyQL returns date-only strings (e.g. "2026-07-03") for TIMESERIES
+        columns, but the declared date-time schema type — and BigQuery's
+        TIMESTAMP column type on load — require a full timestamp value.
+        """
+        if self.replication_key and self.replication_key in row:
+            value = row[self.replication_key]
+            if isinstance(value, str) and re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+                row[self.replication_key] = f"{value}T00:00:00Z"
         return row


### PR DESCRIPTION
## Summary

The `sales_over_time` stream (and any other config-driven `ShopifyQLStream`) was silently broken end-to-end. Found and fixed while debugging a real pipeline run — extraction/discovery reported success with zero errors while the destination table stayed empty.

- **Missing GraphQL `data` envelope unwrap**: `schema` and `parse_response` both read `data.get("shopifyqlQuery")` instead of unwrapping the standard GraphQL `data` envelope (`{"data": {"shopifyqlQuery": {...}}}`). Every response silently resolved to `{}`, no error raised. This was a regression from an earlier PR review round that incorrectly claimed this endpoint has no envelope.
- **`primary_keys`/`replication_key` set before `super().__init__()`**: these are properties backed by `self._primary_keys`/`self._replication_key` on the singer_sdk base `Stream` class, whose `__init__` unconditionally resets both to their defaults. Since the subclass set them *before* calling `super().__init__()`, the configured values were silently wiped every time.
- **Replication key typed as plain `StringType`**: the discovered schema types every column as `StringType` (values are cast downstream in dbt), but the replication key column itself needs a real timestamp-typed schema (`format: date-time`) for singer_sdk's bookmark logic — otherwise it raises `InvalidReplicationKeyException` / `ValueError: not of timestamp type`.
- **Date-only replication key values**: ShopifyQL returns date-only strings (e.g. `"2026-07-03"`) for `TIMESERIES` columns. Once typed as a timestamp, this fails downstream `TIMESTAMP`-typed destination columns (e.g. BigQuery rejects date-only strings for `TIMESTAMP` load). Normalized in `post_process` by appending `T00:00:00Z` when the value is a bare date.

These four bugs compound in sequence — fixing one surfaces the next — which is why they went unnoticed until traced end-to-end against a live pipeline run.

## Test plan
- [x] Verified schema discovery returns the full column set (including `day`) against the live Shopify API
- [x] Verified `replication_key`/`primary_keys` resolve correctly post-construction
- [x] Verified discovered schema types the replication key as a timestamp
- [x] Ran full `meltano run tap-shopify target-bigquery` end-to-end; `sales_over_time` extracted and loaded correctly with no duplicate rows and correct incremental bookmarking

🤖 Generated with [Claude Code](https://claude.com/claude-code)