### PR TITLE
fix: Record validation errors

### DIFF
--- a/tap_shopify/schemas/line_item.json
+++ b/tap_shopify/schemas/line_item.json
@@ -207,11 +207,14 @@
         },
         "properties": {
             "type": [
-                "object",
+                "array",
                 "null"
             ],
-            "properties": {},
-            "additionalProperties": true
+            "items": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": true
+            }
         },
         "quantity": {
             "type": [

--- a/tap_shopify/schemas/order.json
+++ b/tap_shopify/schemas/order.json
@@ -839,7 +839,7 @@
         },
         "tax_exempt": {
             "type": [
-                "string",
+                "boolean",
                 "null"
             ]
         },


### PR DESCRIPTION
When running against an SDK target with `validate_records` set to `true`, we hit a couple of record validation errors:

- `line_items`
  ```console
  jsonschema.exceptions.ValidationError: [] is not of type 'object', 'null'
  
  Failed validating 'type' in schema['properties']['properties']:
      {'additionalProperties': True,
       'properties': {},
       'type': ['object', 'null']}
  
  On instance['properties']:
      []
  ```
- `orders`
  ```console
  jsonschema.exceptions.ValidationError: False is not of type 'string', 'null'
  
  Failed validating 'type' in schema['properties']['tax_exempt']:
      {'type': ['string', 'null']}
  
  On instance['tax_exempt']:
      False
  ```